### PR TITLE
Fixed fatal error

### DIFF
--- a/class-gamajo-template-loader.php
+++ b/class-gamajo-template-loader.php
@@ -67,7 +67,7 @@ class Gamajo_Template_Loader {
 		do_action( 'get_template_part_' . $slug, $slug, $name );
 
 		// Get files names of templates, for given slug and name.
-		$templates = $this->get_template_file_names( $slug, $name );
+		$templates = $this->get_template_possible_parts( $slug, $name );
 
 		// Return the part that is found
 		return $this->locate_template( $templates, $load, false );


### PR DESCRIPTION
When copying the child theme path out of the mail `$file_paths` array and wrapping it in the `is_child_theme()` check, a comma was left. Just needs to be replaced with a `;`.
