### PR TITLE
Make locate_template() method public

### DIFF
--- a/class-gamajo-template-loader.php
+++ b/class-gamajo-template-loader.php
@@ -122,7 +122,7 @@ class Gamajo_Template_Loader {
 	 *
 	 * @return string The template filename if one is located.
 	 */
-	protected function locate_template( $template_names, $load = false, $require_once = true ) {
+	public function locate_template( $template_names, $load = false, $require_once = true ) {
 		// No file found yet
 		$located = false;
 


### PR DESCRIPTION
Template parts have to follow a specific naming pattern when using `get_template_part()`, while `locate_template()` isn't concerned with the template names. For instance, it might be necessary to use a convention similar to the WordPress Template Hierarchy:
- category-slug.php
- category-id.php
- archive.php
- index.php

Another application that can't be achieved with `get_template_part()` is searching for templates that don't use a `.php` extension.
