### PR TITLE
Few Changes

### DIFF
--- a/class-gamajo-template-loader.php
+++ b/class-gamajo-template-loader.php
@@ -55,7 +55,7 @@ class Gamajo_Template_Loader {
 	 * @since 1.0.0
 	 * @type string
 	 */
-	protected $templates_directory = 'templates'; // or includes/templates, etc.
+	protected $plugin_templates_directory = 'templates'; // or includes/templates, etc.
 
 	/**
 	 * Retrieve a template part.
@@ -209,7 +209,7 @@ class Gamajo_Template_Loader {
 	 * @return string
 	 */
 	protected function get_templates_dir() {
-		return trailingslashit( $this->plugin_directory ) . $this->templates_directory;
+		return trailingslashit( $this->plugin_directory ) . $this->plugin_templates_directory;
 	}
 
 }


### PR DESCRIPTION
1. Add trailingslashit to plugin_directory 
2. Allow templates directory to be set by child class
3. Fixed double foreach break within locate_template. I ran into an instance where it was grabbing the generic template over the specific template due to possible names.
