### PR TITLE
Protect fatal errors caused by multiple inclusion.

### DIFF
--- a/class-gamajo-template-loader.php
+++ b/class-gamajo-template-loader.php
@@ -1,14 +1,14 @@
 <?php
-	/**
-	 * Template Loader for Plugins.
-	 *
-	 * @package   Gamajo_Template_Loader
-	 * @author    Gary Jones
-	 * @link      http://github.com/GaryJones/Gamajo-Template-Loader
-	 * @copyright 2013 Gary Jones
-	 * @license   GPL-2.0+
-	 * @version   1.1.0
-	 */
+/**
+ * Template Loader for Plugins.
+ *
+ * @package   Gamajo_Template_Loader
+ * @author    Gary Jones
+ * @link      http://github.com/GaryJones/Gamajo-Template-Loader
+ * @copyright 2013 Gary Jones
+ * @license   GPL-2.0+
+ * @version   1.1.0
+ */
 
 if ( ! class_exists( 'Gamajo_Template_Loader' ) )  {
 	/**


### PR DESCRIPTION
Hi Gary, 

A small change which protects people who may pick this up and use it from fatal errors caused by duplicate class definitions.

Diff best viewed with ?w=0 - e.g. https://github.com/leewillis77/Gamajo-Template-Loader/commit/7939be314622681ef05a0390bfde816b946d34d6?w=0
