### PR TITLE
fix comment -- get_template_file_names instead of get_template_possib…

### DIFF
--- a/class-gamajo-template-loader.php
+++ b/class-gamajo-template-loader.php
@@ -67,7 +67,7 @@ if ( ! class_exists( 'Gamajo_Template_Loader' ) )  {
 		 *
 		 * @since 1.0.0
 		 *
-		 * @uses Gamajo_Template_Loader::get_template_possble_parts() Create file names of templates.
+		 * @uses Gamajo_Template_Loader::get_template_file_names() Create file names of templates.
 		 * @uses Gamajo_Template_Loader::locate_template() Retrieve the name of the highest priority template
 		 *     file that exists.
 		 *


### PR DESCRIPTION
…le_parts

I was going to replace `get_template_possble_parts` with `get_template_possible_parts` to fix the typo, but then I noticed this method does not exist. I believe the correct reference would be to `get_template_file_names`