### PR TITLE
namespace get_template_part action hook

### DIFF
--- a/class-gamajo-template-loader.php
+++ b/class-gamajo-template-loader.php
@@ -91,7 +91,7 @@ if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
 		 */
 		public function get_template_part( $slug, $name = null, $load = true ) {
 			// Execute code for this part.
-			do_action( 'get_template_part_' . $slug, $slug, $name );
+			do_action( 'get_template_part_' . $this->filter_prefix . '_' . $slug, $slug, $name );
 
 			// Get files names of templates, for given slug and name.
 			$templates = $this->get_template_file_names( $slug, $name );


### PR DESCRIPTION
Example:
action hook is now `get_template_part_tk_event_weather_hourly_horizontal` instead of just `get_template_part_hourly_horizontal`
