### PR TITLE
Remove `array` casting from `set_template_data`

### DIFF
--- a/class-gamajo-template-loader.php
+++ b/class-gamajo-template-loader.php
@@ -128,11 +128,11 @@ if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
 		 *
 		 * @since 1.2.0
 		 *
-		 * @param array  $data     Custom data for the template.
+		 * @param mixed  $data     Custom data for the template.
 		 * @param string $var_name Optional. Variable under which the custom data is available in the template.
 		 *                         Default is 'data'.
 		 */
-		public function set_template_data( array $data, $var_name = 'data' ) {
+		public function set_template_data( $data, $var_name = 'data' ) {
 			global $wp_query;
 
 			$wp_query->query_vars[ $var_name ] = (object) $data;


### PR DESCRIPTION
The `$data` var is cast to an object, so no reason to require an array coming in. See: https://github.com/GaryJones/Gamajo-Template-Loader/issues/31#issuecomment-282184854