### PR TITLE
Warning undefined Constants TEMPLATPATH & STYLESHEETPATH

### DIFF
--- a/class-gamajo-template-loader.php
+++ b/class-gamajo-template-loader.php
@@ -282,7 +282,7 @@ if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
 			);
 
 			// Only add this conditionally, so non-child themes don't redundantly check active theme twice.
-			if ( is_child_theme() ) {
+			if ( get_stylesheet_directory() != get_template_directory() ) {
 				$file_paths[1] = trailingslashit( get_stylesheet_directory() ) . $theme_directory;
 			}
 


### PR DESCRIPTION
default variable not loaded reliably by teh time is_child_theme called

line 285 calls is_child_theme
Which simply is 
function is_child_theme() {
	return ( TEMPLATEPATH !== STYLESHEETPATH );
}

However - for some reason I can't fathom,  wp-includes/default-constants.php is not reliably called before this conditional, so re-coding using the directory functions removes this warning ( and possible invalid check ). the directory functions seem reliable even when the constants not defined.  (although a small processing overhead )