### PR TITLE
Suggest installing and using Mozart via composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,21 @@ The `get_template_part()` function in WordPress was never really designed with p
 
 This isn't a WordPress plugin on its own, so the usual instructions don't apply. Instead:
 
+### Manually install class
 1. Copy [`class-gamajo-template-loader.php`](class-gamajo-template-loader.php) into your plugin. It can be into a file in the plugin root, or better, an `includes` directory.
-2. Create a new file, such as `class-your-plugin-template-loader.php`, in the same directory.
-3. Create a class in that file that extends `Gamajo_Template_Loader`. You can see the Meal Planner Template Loader example class below as a starting point if it helps.
-4. Override the class properties to suit your plugin. You could also override the `get_templates_dir()` method if it isn't right for you.
-5. You can now instantiate your custom template loader class, and use it to call the `get_template_part()` method. This could be within a shortcode callback, or something you want theme developers to include in their files.
+
+or:
+
+### Install class via Composer
+1. Tell Composer to install this class as a dependency: `composer require gamajo/template-loader`
+2. Recommended: Install the Mozart package: `composer require coenjacobs/mozart --dev` and [configure it](https://github.com/coenjacobs/mozart#configuration).
+3. The class is now renamed to use your own prefix, to prevent collisions with other plugins bundling this class.
+
+## Implement class
+1. Create a new file, such as `class-your-plugin-template-loader.php`, in the same directory.
+2. Create a class in that file that extends `Gamajo_Template_Loader`. You can see the Meal Planner Template Loader example class below as a starting point if it helps.
+3. Override the class properties to suit your plugin. You could also override the `get_templates_dir()` method if it isn't right for you.
+4. You can now instantiate your custom template loader class, and use it to call the `get_template_part()` method. This could be within a shortcode callback, or something you want theme developers to include in their files.
 
   ~~~php
   // Template loader instantiated elsewhere, such as the main plugin file.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ or:
 
 ## Implement class
 1. Create a new file, such as `class-your-plugin-template-loader.php`, in the same directory.
-2. Create a class in that file that extends `Gamajo_Template_Loader`. You can see the Meal Planner Template Loader example class below as a starting point if it helps.
+2. Create a class in that file that extends `Gamajo_Template_Loader` (or the new prefixed name, if you installed via Composer/Mozart). You can see the Meal Planner Template Loader example class below as a starting point if it helps.
 3. Override the class properties to suit your plugin. You could also override the `get_templates_dir()` method if it isn't right for you.
 4. You can now instantiate your custom template loader class, and use it to call the `get_template_part()` method. This could be within a shortcode callback, or something you want theme developers to include in their files.
 

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,8 @@
 	},
 	"autoload"   : {
 		"classmap": ["class-gamajo-template-loader.php"]
+	},
+	"suggest"    : {
+		"coenjacobs/mozart": "Easily wrap this library with your own prefix, to prevent collisions when multiple plugins use this library"
 	}
 }


### PR DESCRIPTION
This suggests using the `coenjacobs/mozart` package to automatically rewrite the class to use a prefix in order to prevent collisions with other plugins bundling the same class but in a different (non-compatible) version.

We've implemented it this way in our base plugin: https://github.com/Mindsize/wp-plugin-base/pull/2 using this exact class (which is great btw, thank you!).

I've written a bunch of posts and documentation on this subject to further investigate before your merge, if you prefer:
* [Introduction post](https://coenjacobs.me/2017/03/07/mozart-monkey-patches-wordpress-lack-dependency-management/)
* [Actual bug report of a version collision](https://github.com/WPupdatePHP/wp-update-php/issues/37)
* [More detailed link post to describe collision problem](https://coenjacobs.me/2015/06/18/explaining-wordpress-plugins-dependencies-problem/)