### PR TITLE
Added support for WP 5.5 get_template args parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,28 +39,16 @@ or:
   ~~~php
   $meal_planner_template_loader->get_template_part( 'recipe' );
   ~~~
-* If you want to pass data to the template, call the `set_template_data()` method with an array before calling `get_template_part()`. `set_template_data()` returns the loader object to allow for method chaining.
+* If you want to pass data to the template, use the `$args` parameter like in `get_template_part` since WordPress 5.5.
 
   ~~~php
   $data = array( 'foo' => 'bar', 'baz' => 'boom' );
   $meal_planner_template_loader
-      ->set_template_data( $data );
-      ->get_template_part( 'recipe' );
+      ->get_template_part( 'recipe', null, $data );
   ~~~
   
-  The value of `bar` is now available inside the recipe template as `$data->foo`.
+  The value of `foo` is now available inside the recipe template as `$args['foo']`.
   
-  If you wish to use a different variable name, add a second parameter to `set_template_data()`:
-
-  ~~~php
-  $data = array( 'foo' => 'bar', 'baz' => 'boom' );
-  $meal_planner_template_loader
-      ->set_template_data( $data, 'context' )
-      ->get_template_part( 'recipe', 'ingredients' );
-  ~~~
-  
-  The value of `bar` is now available inside the recipe template as `$context->foo`.
-
   This will try to load up `wp-content/themes/my-theme/meal-planner/recipe-ingredients.php`, or `wp-content/themes/my-theme/meal-planner/recipe.php`, then fallback to `wp-content/plugins/meal-planner/templates/recipe-ingredients.php` or `wp-content/plugins/meal-planner/templates/recipe.php`.
 
 ### Meal Planner Example Class

--- a/class-gamajo-template-loader.php
+++ b/class-gamajo-template-loader.php
@@ -7,7 +7,7 @@
  * @link      http://github.com/GaryJones/Gamajo-Template-Loader
  * @copyright 2013 Gary Jones
  * @license   GPL-2.0-or-later
- * @version   1.3.1
+ * @version   1.4.0
  */
 
 if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
@@ -103,19 +103,20 @@ if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
 		 *
 		 * @param string $slug Template slug.
 		 * @param string $name Optional. Template variation name. Default null.
+		 * @param array  $args Optional. Variables passed to template. Default empty array.
 		 * @param bool   $load Optional. Whether to load template. Default true.
 		 * @return string
 		 */
-		public function get_template_part( $slug, $name = null, $load = true ) {
+		public function get_template_part( $slug, $name = null, $args = array(), $load = true ) {
 			// Execute code for this part.
-			do_action( 'get_template_part_' . $slug, $slug, $name );
-			do_action( $this->filter_prefix . '_get_template_part_' . $slug, $slug, $name );
+			do_action( 'get_template_part_' . $slug, $slug, $name, $args );
+			do_action( $this->filter_prefix . '_get_template_part_' . $slug, $slug, $name, $args );
 
 			// Get files names of templates, for given slug and name.
-			$templates = $this->get_template_file_names( $slug, $name );
+			$templates = $this->get_template_file_names( $slug, $name, $args );
 
 			// Return the part that is found.
-			return $this->locate_template( $templates, $load, false );
+			return $this->locate_template( $templates, $load, false, $args );
 		}
 
 		/**
@@ -135,7 +136,7 @@ if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
 		 */
 		public function set_template_data( $data, $var_name = 'data' ) {
 			global $wp_query;
-
+			_deprecated_function( 'set_template_data', '1.4.0' );
 			$wp_query->query_vars[ $var_name ] = (object) $data;
 
 			// Add $var_name to custom variable store if not default value.
@@ -157,7 +158,7 @@ if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
 		 */
 		public function unset_template_data() {
 			global $wp_query;
-
+			_deprecated_function( 'unset_template_data', '1.4.0' );
 			// Remove any duplicates from the custom variable store.
 			$custom_var_names = array_unique( $this->template_data_var_names );
 
@@ -178,9 +179,10 @@ if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
 		 *
 		 * @param string $slug Template slug.
 		 * @param string $name Template variation name.
+		 * @param array  $args Optional. Variables passed to template.
 		 * @return array
 		 */
-		protected function get_template_file_names( $slug, $name ) {
+		protected function get_template_file_names( $slug, $name, $args ) {
 			$templates = array();
 			if ( isset( $name ) ) {
 				$templates[] = $slug . '-' . $name . '.php';
@@ -199,7 +201,7 @@ if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
 			 * @param string $slug      Template slug.
 			 * @param string $name      Template variation name.
 			 */
-			return apply_filters( $this->filter_prefix . '_get_template_part', $templates, $slug, $name );
+			return apply_filters( $this->filter_prefix . '_get_template_part', $templates, $slug, $name, $args );
 		}
 
 		/**
@@ -215,9 +217,11 @@ if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
 		 * @param bool         $load           If true the template file will be loaded if it is found.
 		 * @param bool         $require_once   Whether to require_once or require. Default true.
 		 *                                     Has no effect if $load is false.
+		 * @param array        $args Optional. Variables passed to template. Default empty array.
+		 *
 		 * @return string The template filename if one is located.
 		 */
-		public function locate_template( $template_names, $load = false, $require_once = true ) {
+		public function locate_template( $template_names, $load = false, $require_once = true, $args = array() ) {
 
 			// Use $template_names as a cache key - either first element of array or the variable itself if it's a string.
 			$cache_key = is_array( $template_names ) ? $template_names[0] : $template_names;
@@ -252,7 +256,7 @@ if ( ! class_exists( 'Gamajo_Template_Loader' ) ) {
 			}
 
 			if ( $load && $located ) {
-				load_template( $located, $require_once );
+				load_template( $located, $require_once, $args );
 			}
 
 			return $located;


### PR DESCRIPTION
As mentioned in #39 - get_template_part has a support for $args variable now.

Currently it's not compatible with WP < 5.5. I was thinking a bit about how add such a compatibility - it's possible and would require two things:
- changing a bit order of parameters to set $args at the end (which is would not be exactly the same as in native get_template_part function)
- wrap all cases of using methods with `$args` in a WP version check like
```php
if ( WP_VERSION < 5.5 ) {
do_action( 'get_template_part_' . $slug, $slug, $name );
} else {
do_action( 'get_template_part_' . $slug, $slug, $name, $args );
}
```

Personally I think that starting a major, breaking version is the better way.